### PR TITLE
Dockerファイルをbuildできるようにした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,4 @@ COPY Gemfile.lock /rubyPractice/Gemfile.lock
 RUN bundle install
 COPY . /rubyPractice
 
-COPY entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3000

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby:3.2.2
-
 gem 'rails', '~> 7.0.0'
 
 #app server


### PR DESCRIPTION
# Dockerファイルをbuildできるようにした

## 原因
Gemfileのsyntaxエラーによってbuildができなくなっていたので
その箇所を修正