### PR TITLE
issues/11 phpMyadminの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # rubyPractice
+
+## DB・テーブル確認手法
+
+## コンテナ内に入ってmysqlにログインする場合
+
+以下の手順でログインする
+
+```
+docker exec -ti db /bin/bash
+mysql -u root -p 
+=> password
+```
+
+## phpMyadminを使って表示する場合
+
+以下の手順で表示する
+
+```
+http://localhost:9999/にアクセス
+```
+
+<img width="766" alt="スクリーンショット 2023-11-02 21 05 18" src="https://github.com/maho-na510/rubyPractice/assets/34295276/500ac6a1-952f-4881-8d36-6beb2296d14c">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,19 @@
 version: "3.9"
 services:
   db:
-    container_name: rubyPractice_db
+    container_name: db
     image: mysql:8.0
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
     volumes:
       - mysql-data:/var/lib/mysql
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      - MYSQL_DATABASE=db
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_USER=user_name
+      - MYSQL_PASSWORD=password
     ports:
       - '3306:3306'
-    
+      
   web:
     container_name: rubyPractice_web
     build: nakahara_app
@@ -21,6 +25,19 @@ services:
       - db
     stdin_open: true
     tty: true
+
+  phpmyadmin:
+    container_name: phpmyadmin_host
+    depends_on:
+      - db
+    image: phpmyadmin/phpmyadmin
+    ports:
+      - "9999:80"
+    environment:
+      - PMA_ARBITRARY=1
+      - PMA_HOST=db
+      - PMA_USER=root
+      - PMA_PASSWORD=password
 
 volumes:
   mysql-data:


### PR DESCRIPTION
# issues/11 phpMyadminの追加

## issues URL
https://github.com/maho-na510/rubyPractice/issues/11


## 変更概要点
- Readme.mdにDBへのアクセス方法を記載
- Readme.mdの表示に関しては、このURLから確認してください(https://github.com/maho-na510/rubyPractice/tree/issues/11)
- 命名を変更(立ち上がってるdbが一つだけだったのでrubyPractice_dbからdbに変更しました)
- localhost:9999にアクセスしたらphpMyadminが出るようにしました